### PR TITLE
Lt 4688 Extend activity entity for additional info

### DIFF
--- a/src/MarginTrading.Activities.Broker/Application.cs
+++ b/src/MarginTrading.Activities.Broker/Application.cs
@@ -59,7 +59,7 @@ namespace MarginTrading.Activities.Broker
             }
             
             var activity = new Activity(contract.Id, contract.AccountId, contract.Instrument, contract.EventSourceId,
-                contract.Timestamp, contract.Event.ToType<ActivityType>(), contract.DescriptionAttributes, contract.RelatedIds, correlationId);
+                contract.Timestamp, contract.Event.ToType<ActivityType>(), contract.DescriptionAttributes, contract.RelatedIds, correlationId, contract.AdditionalInfo);
 
             try
             {

--- a/src/MarginTrading.Activities.Contracts/Models/ActivityContract.cs
+++ b/src/MarginTrading.Activities.Contracts/Models/ActivityContract.cs
@@ -12,7 +12,7 @@ namespace Lykke.MarginTrading.Activities.Contracts.Models
     {
         public ActivityContract(string id, string accountId, string instrument, string eventSourceId,
             DateTime timestamp, ActivityCategoryContract category, ActivityTypeContract @event,
-            string[] descriptionAttributes, string[] relatedIds)
+            string[] descriptionAttributes, string[] relatedIds, string additionalInfo = null)
         {
             Id = id;
             AccountId = accountId;
@@ -23,6 +23,7 @@ namespace Lykke.MarginTrading.Activities.Contracts.Models
             RelatedIds = relatedIds;
             EventSourceId = eventSourceId;
             Category = category;
+            AdditionalInfo = additionalInfo;
         }
 
         [Key(0)]
@@ -51,5 +52,8 @@ namespace Lykke.MarginTrading.Activities.Contracts.Models
         
         [Key(8)]
         public string[] RelatedIds { get; }
+
+        [Key(9)]
+        public string AdditionalInfo { get; }
     }
 }

--- a/src/MarginTrading.Activities.Core/Domain/Abstractions/IActivity.cs
+++ b/src/MarginTrading.Activities.Core/Domain/Abstractions/IActivity.cs
@@ -25,6 +25,9 @@ namespace MarginTrading.Activities.Core.Domain.Abstractions
         string[] DescriptionAttributes { get; }
 
         string[] RelatedIds { get; }
+
         string CorrelationId { get; }
+
+        string AdditionalInfo { get; }
     }
 }

--- a/src/MarginTrading.Activities.Core/Domain/Activity.cs
+++ b/src/MarginTrading.Activities.Core/Domain/Activity.cs
@@ -11,7 +11,7 @@ namespace MarginTrading.Activities.Core.Domain
     {
         public Activity(string id, string accountId, string instrument, string eventSourceId,
             DateTime timestamp, ActivityType @event, string[] descriptionAttributes, string[] relatedIds,
-            string correlationId = null)
+            string correlationId = null, string additionalInfo = null)
         {
             Id = id;
             AccountId = accountId;
@@ -22,6 +22,7 @@ namespace MarginTrading.Activities.Core.Domain
             RelatedIds = relatedIds;
             EventSourceId = eventSourceId;
             CorrelationId = correlationId;
+            AdditionalInfo = additionalInfo;
         }
 
         public string Id { get; }
@@ -35,5 +36,6 @@ namespace MarginTrading.Activities.Core.Domain
         public string[] DescriptionAttributes { get; }
         public string[] RelatedIds { get; }
         public string CorrelationId { get; }
+        public string AdditionalInfo { get; }
     }
 }

--- a/src/MarginTrading.Activities.Services/ActivitiesSender.cs
+++ b/src/MarginTrading.Activities.Services/ActivitiesSender.cs
@@ -80,7 +80,8 @@ namespace MarginTrading.Activities.Services
                         activityCategory,
                         activityType,
                         activity.DescriptionAttributes,
-                        activity.RelatedIds)
+                        activity.RelatedIds,
+                        activity.AdditionalInfo)
                 };
 
                 CqrsEngine.PublishEvent(@event, _activities);

--- a/src/MarginTrading.Activities.Services/Projections/OrdersProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/OrdersProjection.cs
@@ -310,7 +310,7 @@ namespace MarginTrading.Activities.Services.Projections
                 activityType,
                 descriptionAttributes.ToArray(),
                 relatedIds,
-                additionalInfo: additionalInfo.ToJson()
+                additionalInfo: isOnBehalf ? new { IsOnBehalf = true }.ToJson() : null
             );
 
             _cqrsSender.PublishActivity(activity);

--- a/src/MarginTrading.Activities.Services/Projections/OrdersProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/OrdersProjection.cs
@@ -294,12 +294,7 @@ namespace MarginTrading.Activities.Services.Projections
         private void PublishActivity(OrderHistoryEvent historyEvent, OrderContract order, ActivityType activityType,
             List<string> descriptionAttributes, string[] relatedIds)
         {
-            dynamic additionalInfo = new {};
-
             var isOnBehalf = CheckIfOnBehalf(historyEvent);
-            
-            if(isOnBehalf)
-                additionalInfo.IsOnBehalf = true;
             
             var activity = new Activity(
                 _identityGenerator.GenerateId(),

--- a/src/MarginTrading.Activities.Services/Projections/PositionsProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/PositionsProjection.cs
@@ -143,12 +143,7 @@ namespace MarginTrading.Activities.Services.Projections
                     return Task.CompletedTask;
             }
 
-            dynamic additionalInfo = new {};
-
             var isOnBehalf = CheckIfOnBehalf(historyEvent);
-            
-            if(isOnBehalf)
-                additionalInfo.IsOnBehalf = true;
             
             var activity = new Activity(
                 _identityGenerator.GenerateId(),
@@ -159,7 +154,7 @@ namespace MarginTrading.Activities.Services.Projections
                 activityType,
                 descriptionAttributes,
                 relatedIds,
-                additionalInfo: additionalInfo.ToJson()
+                additionalInfo: isOnBehalf ? new { IsOnBehalf = true }.ToJson() : null
             );
 
             _cqrsSender.PublishActivity(activity);

--- a/src/MarginTrading.Activities.SqlRepositories/ActivitiesRepository.cs
+++ b/src/MarginTrading.Activities.SqlRepositories/ActivitiesRepository.cs
@@ -20,19 +20,20 @@ namespace MarginTrading.Activities.SqlRepositories
         private const string TableName = "Activities";
 
         private const string CreateTableScript = "CREATE TABLE [{0}](" +
-                                                 @"[OID] [bigint] NOT NULL IDENTITY (1,1),
-[Id] [nvarchar](128) NOT NULL,
-[AccountId] [nvarchar](128) NOT NULL,
-[Instrument] [nvarchar](128) NULL,
-[EventSourceId] [nvarchar](128) NOT NULL,
-[Timestamp] [datetime] NOT NULL,
-[Category] [nvarchar](128) NOT NULL,
-[Event] [nvarchar](128) NOT NULL,
-[DescriptionAttributes] [nvarchar](MAX) NOT NULL,
-[RelatedIds] [nvarchar](MAX) NOT NULL,
-INDEX IX_{0}_Base (AccountId, Instrument, EventSourceId, Timestamp, Category, Event),
-INDEX IX_{0}_Id UNIQUE (Id)
-);";
+                                                @"[OID] [bigint] NOT NULL IDENTITY (1,1),
+                                                  [Id] [nvarchar](128) NOT NULL,
+                                                  [AccountId] [nvarchar](128) NOT NULL,
+                                                  [Instrument] [nvarchar](128) NULL,
+                                                  [EventSourceId] [nvarchar](128) NOT NULL,
+                                                  [Timestamp] [datetime] NOT NULL,
+                                                  [Category] [nvarchar](128) NOT NULL,
+                                                  [Event] [nvarchar](128) NOT NULL,
+                                                  [DescriptionAttributes] [nvarchar](MAX) NOT NULL,
+                                                  [RelatedIds] [nvarchar](MAX) NOT NULL,
+                                                  [AdditionalInfo] [nvarchar](MAX) NULL,
+                                                  INDEX IX_{0}_Base (AccountId, Instrument, EventSourceId, Timestamp, Category, Event),
+                                                  INDEX IX_{0}_Id UNIQUE (Id)
+                                                  );";
 
         private const string AddCorrelationIdScript = @"IF NOT EXISTS (
 SELECT * 

--- a/src/MarginTrading.Activities.SqlRepositories/ActivityEntity.cs
+++ b/src/MarginTrading.Activities.SqlRepositories/ActivityEntity.cs
@@ -46,6 +46,8 @@ namespace MarginTrading.Activities.SqlRepositories
         
         public string CorrelationId { get; set; }
 
+        public string AdditionalInfo { get; set; }
+
         public static ActivityEntity Create(IActivity activity)
         {
             return new ActivityEntity
@@ -59,7 +61,8 @@ namespace MarginTrading.Activities.SqlRepositories
                 Event = activity.Event.ToString(),
                 DescriptionAttributes = activity.DescriptionAttributes.ToJson(),
                 RelatedIds = activity.RelatedIds.ToJson(),
-                CorrelationId = activity.CorrelationId
+                CorrelationId = activity.CorrelationId,
+                AdditionalInfo = activity.AdditionalInfo
             };
         }
     }

--- a/src/MarginTrading.Activities.SqlRepositories/Scripts/LT-4688-add-additional-info-column.sql
+++ b/src/MarginTrading.Activities.SqlRepositories/Scripts/LT-4688-add-additional-info-column.sql
@@ -1,0 +1,4 @@
+-- Add AdditionalInfo column to Activities table
+
+ALTER TABLE [dbo].Activities
+ADD AdditionalInfo [nvarchar](MAX) NULL;

--- a/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
@@ -12,13 +12,17 @@ namespace MarginTrading.Activites.Tests
     public class OrdersProjectionTests
     {
         [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsNotJsonString()
+        [TestCase(OriginatorTypeContract.Investor, false)]
+        [TestCase(OriginatorTypeContract.OnBehalf, true)]
+        [TestCase(OriginatorTypeContract.System, false)]
+        public void CheckIfOnBehalf_ShouldReturnTheCorrectValue_BasedOnOriginator(OriginatorTypeContract originator,
+            bool expectedResult)
         {
             var orderHistoryEvent = new OrderHistoryEvent
             {
                 OrderSnapshot = new OrderContract
                 {
-                    AdditionalInfo = "not-json-string"
+                    Originator = originator
                 }
             };
             
@@ -26,99 +30,9 @@ namespace MarginTrading.Activites.Tests
             
             var result = sut.CheckIfOnBehalf(orderHistoryEvent);
             
-            Assert.False(result);
+            Assert.AreEqual(expectedResult, result);
         }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsEmptyObject()
-        {
-            var orderHistoryEvent = new OrderHistoryEvent
-            {
-                OrderSnapshot = new OrderContract
-                {
-                    AdditionalInfo = "{}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyDoesntExist()
-        {
-            var orderHistoryEvent = new OrderHistoryEvent
-            {
-                OrderSnapshot = new OrderContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyInvalid()
-        {
-            var orderHistoryEvent = new OrderHistoryEvent
-            {
-                OrderSnapshot = new OrderContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertySetToFalse()
-        {
-            var orderHistoryEvent = new OrderHistoryEvent
-            {
-                OrderSnapshot = new OrderContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnTrue_IfIsOnBehalfPropertySetToTrue()
-        {
-            var orderHistoryEvent = new OrderHistoryEvent
-            {
-                OrderSnapshot = new OrderContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
-            
-            Assert.True(result);
-        }
-
+        
         private OrdersProjection CreateSut()
         {
             var mockRabbitMqSubscriberService = new Mock<IRabbitMqSubscriberService>();

--- a/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
@@ -1,0 +1,120 @@
+using Common.Log;
+using MarginTrading.Activities.Core.Settings;
+using MarginTrading.Activities.Services.Abstractions;
+using MarginTrading.Activities.Services.Projections;
+using MarginTrading.Backend.Contracts.Events;
+using Moq;
+using NUnit.Framework;
+
+namespace MarginTrading.Activites.Tests
+{
+    public class OrdersProjectionTests
+    {
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsNotJsonString()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = "not-json-string"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsEmptyObject()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = "{}"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyDoesntExist()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyInvalid()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertySetToFalse()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnTrue_IfIsOnBehalfPropertySetToTrue()
+        {
+            var orderHistoryEvent = new OrderHistoryEvent()
+            {
+                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(orderHistoryEvent);
+            
+            Assert.True(result);
+        }
+
+        private OrdersProjection CreateSut()
+        {
+            var mockRabbitMqSubscriberService = new Mock<IRabbitMqSubscriberService>();
+            var mockActivitiesSender = new Mock<IActivitiesSender>();
+            var mockIdentityGenerator = new Mock<IIdentityGenerator>();
+            var mockLog = new Mock<ILog>();
+            var mockAssetPairCacheService = new Mock<IAssetPairsCacheService>();
+            
+            return new OrdersProjection(
+                mockRabbitMqSubscriberService.Object,
+                new ActivitiesSettings(),
+                mockActivitiesSender.Object,
+                mockIdentityGenerator.Object,
+                mockLog.Object,
+                mockAssetPairCacheService.Object);
+        }
+    }
+}

--- a/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/OrdersProjectionTests.cs
@@ -3,6 +3,7 @@ using MarginTrading.Activities.Core.Settings;
 using MarginTrading.Activities.Services.Abstractions;
 using MarginTrading.Activities.Services.Projections;
 using MarginTrading.Backend.Contracts.Events;
+using MarginTrading.Backend.Contracts.Orders;
 using Moq;
 using NUnit.Framework;
 
@@ -13,9 +14,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsNotJsonString()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = "not-json-string"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = "not-json-string"
+                }
             };
             
             var sut = CreateSut();
@@ -28,9 +32,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsEmptyObject()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = "{}"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = "{}"
+                }
             };
             
             var sut = CreateSut();
@@ -43,9 +50,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyDoesntExist()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
+                }
             };
             
             var sut = CreateSut();
@@ -58,9 +68,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyInvalid()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
+                }
             };
             
             var sut = CreateSut();
@@ -73,9 +86,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertySetToFalse()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
+                }
             };
             
             var sut = CreateSut();
@@ -88,9 +104,12 @@ namespace MarginTrading.Activites.Tests
         [Test]
         public void CheckIfOnBehalf_ShouldReturnTrue_IfIsOnBehalfPropertySetToTrue()
         {
-            var orderHistoryEvent = new OrderHistoryEvent()
+            var orderHistoryEvent = new OrderHistoryEvent
             {
-                ActivitiesMetadata = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
+                OrderSnapshot = new OrderContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
+                }
             };
             
             var sut = CreateSut();

--- a/tests/MarginTrading.Activities.Tests/PositionsProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/PositionsProjectionTests.cs
@@ -1,0 +1,140 @@
+using Common.Log;
+using MarginTrading.Activities.Core.Settings;
+using MarginTrading.Activities.Services.Abstractions;
+using MarginTrading.Activities.Services.Projections;
+using MarginTrading.Backend.Contracts.Events;
+using MarginTrading.Backend.Contracts.Orders;
+using MarginTrading.Backend.Contracts.Positions;
+using Moq;
+using NUnit.Framework;
+
+namespace MarginTrading.Activites.Tests
+{
+    public class PositionsProjectionTests
+    {
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsNotJsonString()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = "not-json-string"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsEmptyObject()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = "{}"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyDoesntExist()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyInvalid()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertySetToFalse()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.False(result);
+        }
+
+        [Test]
+        public void CheckIfOnBehalf_ShouldReturnTrue_IfIsOnBehalfPropertySetToTrue()
+        {
+            var positionHistoryEvent = new PositionHistoryEvent
+            {
+                PositionSnapshot = new PositionContract
+                {
+                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
+                }
+            };
+            
+            var sut = CreateSut();
+            
+            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
+            
+            Assert.True(result);
+        }
+
+        private PositionsProjection CreateSut()
+        {
+            var mockRabbitMqSubscriberService = new Mock<IRabbitMqSubscriberService>();
+            var mockActivitiesSender = new Mock<IActivitiesSender>();
+            var mockIdentityGenerator = new Mock<IIdentityGenerator>();
+            var mockLog = new Mock<ILog>();
+            var mockAssetPairCacheService = new Mock<IAssetPairsCacheService>();
+            
+            return new PositionsProjection(
+                mockRabbitMqSubscriberService.Object,
+                new ActivitiesSettings(),
+                mockActivitiesSender.Object,
+                mockIdentityGenerator.Object,
+                mockLog.Object,
+                mockAssetPairCacheService.Object);
+        }
+    }
+}

--- a/tests/MarginTrading.Activities.Tests/PositionsProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/PositionsProjectionTests.cs
@@ -13,13 +13,31 @@ namespace MarginTrading.Activites.Tests
     public class PositionsProjectionTests
     {
         [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsNotJsonString()
+        [TestCase(PositionHistoryTypeContract.Open, OriginatorTypeContract.Investor, null, false)]
+        [TestCase(PositionHistoryTypeContract.Open, OriginatorTypeContract.OnBehalf, null, true)]
+        [TestCase(PositionHistoryTypeContract.Open, OriginatorTypeContract.System, null, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.Investor, OriginatorTypeContract.Investor, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.Investor, OriginatorTypeContract.OnBehalf, true)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.Investor, OriginatorTypeContract.System, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.OnBehalf, OriginatorTypeContract.Investor, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.OnBehalf, OriginatorTypeContract.OnBehalf, true)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.OnBehalf, OriginatorTypeContract.System, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.System, OriginatorTypeContract.Investor, false)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.System, OriginatorTypeContract.OnBehalf, true)]
+        [TestCase(PositionHistoryTypeContract.Close, OriginatorTypeContract.System, OriginatorTypeContract.System, false)]
+        public void CheckIfOnBehalf_ShouldReturnCorrectValues_BasedOnOriginator(
+            PositionHistoryTypeContract historyType,
+            OriginatorTypeContract openOriginator, 
+            OriginatorTypeContract? closeOriginator, 
+            bool expectedResult)
         {
             var positionHistoryEvent = new PositionHistoryEvent
             {
+                EventType = historyType,
                 PositionSnapshot = new PositionContract
                 {
-                    AdditionalInfo = "not-json-string"
+                    OpenOriginator = openOriginator,
+                    CloseOriginator = closeOriginator
                 }
             };
             
@@ -27,97 +45,7 @@ namespace MarginTrading.Activites.Tests
             
             var result = sut.CheckIfOnBehalf(positionHistoryEvent);
             
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfInputIsEmptyObject()
-        {
-            var positionHistoryEvent = new PositionHistoryEvent
-            {
-                PositionSnapshot = new PositionContract
-                {
-                    AdditionalInfo = "{}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyDoesntExist()
-        {
-            var positionHistoryEvent = new PositionHistoryEvent
-            {
-                PositionSnapshot = new PositionContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44""}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertyInvalid()
-        {
-            var positionHistoryEvent = new PositionHistoryEvent
-            {
-                PositionSnapshot = new PositionContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": """"}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnFalse_IfIsOnBehalfPropertySetToFalse()
-        {
-            var positionHistoryEvent = new PositionHistoryEvent
-            {
-                PositionSnapshot = new PositionContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": false}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
-            
-            Assert.False(result);
-        }
-
-        [Test]
-        public void CheckIfOnBehalf_ShouldReturnTrue_IfIsOnBehalfPropertySetToTrue()
-        {
-            var positionHistoryEvent = new PositionHistoryEvent
-            {
-                PositionSnapshot = new PositionContract
-                {
-                    AdditionalInfo = @"{""CreatedBy"": ""user1"", ""CreatedAt"": ""2023-04-26T09:44"", ""IsOnBehalf"": true}"
-                }
-            };
-            
-            var sut = CreateSut();
-            
-            var result = sut.CheckIfOnBehalf(positionHistoryEvent);
-            
-            Assert.True(result);
+            Assert.AreEqual(expectedResult, result);
         }
 
         private PositionsProjection CreateSut()


### PR DESCRIPTION
This PR adds `AdditionalInfo` column to the `dbo.Activities` table and related entities to store JSON-encoded additional information related to the particular activity. 

And changes to store `IsOnBehalf` information on `AdditionalInfo` column

