### PR TITLE
Lt 4759 Use account name in activities where applicable

### DIFF
--- a/src/MarginTrading.Activities.Services/Abstractions/IAccountsService.cs
+++ b/src/MarginTrading.Activities.Services/Abstractions/IAccountsService.cs
@@ -8,5 +8,12 @@ namespace MarginTrading.Activities.Services.Abstractions
     public interface IAccountsService
     {
         Task<string> GetAccountNameByAccountId(string id);
+        
+        /// <summary>
+        /// Returns AccountName if there's an AccountName for the account, AccountId if not.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<string> GetEitherAccountNameOrAccountId(string id);
     }
 }

--- a/src/MarginTrading.Activities.Services/AccountService.cs
+++ b/src/MarginTrading.Activities.Services/AccountService.cs
@@ -22,5 +22,12 @@ namespace MarginTrading.Activities.Services
 
             return response?.AccountName;
         }
+
+        public async Task<string> GetEitherAccountNameOrAccountId(string id)
+        {
+            var accountName = await GetAccountNameByAccountId(id);
+            
+            return string.IsNullOrEmpty(accountName) ? id : accountName;
+        }
     }
 }

--- a/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
@@ -53,24 +53,15 @@ namespace MarginTrading.Activities.Services.Projections
         {
             switch (activityType)
             {
+                case ActivityType.AccountTradingDisabled:
                 case ActivityType.AccountComplexityWarningEnabled:
+                case ActivityType.AccountTradingEnabled:
+                case ActivityType.AccountWithdrawalDisabled:
+                case ActivityType.AccountWithdrawalEnabled:
                     return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
 
                 case ActivityType.AccountComplexityWarningDisabled:
                     return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id), e.ActivitiesMetadata?.DeserializeJson<AccountChangeMetadata>()?.OrderId };
-
-                case ActivityType.AccountTradingDisabled:
-                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
-
-                case ActivityType.AccountTradingEnabled:
-                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
-
-                case ActivityType.AccountWithdrawalDisabled:
-                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
-
-                case ActivityType.AccountWithdrawalEnabled:
-                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
-                
                 default: return new string[0];
             }
         }

--- a/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
@@ -55,8 +55,21 @@ namespace MarginTrading.Activities.Services.Projections
             {
                 case ActivityType.AccountComplexityWarningEnabled:
                     return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
+
                 case ActivityType.AccountComplexityWarningDisabled:
                     return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id), e.ActivitiesMetadata?.DeserializeJson<AccountChangeMetadata>()?.OrderId };
+
+                case ActivityType.AccountTradingDisabled:
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
+
+                case ActivityType.AccountTradingEnabled:
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
+
+                case ActivityType.AccountWithdrawalDisabled:
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
+
+                case ActivityType.AccountWithdrawalEnabled:
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
                 
                 default: return new string[0];
             }

--- a/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/AccountsProjection.cs
@@ -17,16 +17,19 @@ namespace MarginTrading.Activities.Services.Projections
     {
         private readonly IActivitiesSender _cqrsSender;
         private readonly IIdentityGenerator _identityGenerator;
+        private readonly IAccountsService _accountService;
 
         public AccountsProjection(
             IActivitiesSender cqrsSender,
-            IIdentityGenerator identityGenerator)
+            IIdentityGenerator identityGenerator,
+            IAccountsService accountService)
         {
             _cqrsSender = cqrsSender;
             _identityGenerator = identityGenerator;
+            _accountService = accountService;
         }
         [UsedImplicitly]
-        public Task Handle(AccountChangedEvent e)
+        public async Task Handle(AccountChangedEvent e)
         {
             var activityTypes = GetActivityTypes(e);
 
@@ -39,23 +42,21 @@ namespace MarginTrading.Activities.Services.Projections
                     e.Account.Id,
                     e.ChangeTimestamp,
                     activityType,
-                    GetDescriptionAttributes(activityType, e),
+                    await GetDescriptionAttributes(activityType, e),
                     new string[0]);
 
                 _cqrsSender.PublishActivity(activity);
             }
-            
-            return Task.CompletedTask;
         }
 
-        private string[] GetDescriptionAttributes(ActivityType activityType, AccountChangedEvent e)
+        private async Task<string[]> GetDescriptionAttributes(ActivityType activityType, AccountChangedEvent e)
         {
             switch (activityType)
             {
                 case ActivityType.AccountComplexityWarningEnabled:
-                    return new[] { e.Account.Id };
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id) };
                 case ActivityType.AccountComplexityWarningDisabled:
-                    return new[] { e.Account.Id, e.ActivitiesMetadata?.DeserializeJson<AccountChangeMetadata>()?.OrderId };
+                    return new[] { await _accountService.GetEitherAccountNameOrAccountId(e.Account.Id), e.ActivitiesMetadata?.DeserializeJson<AccountChangeMetadata>()?.OrderId };
                 
                 default: return new string[0];
             }

--- a/src/MarginTrading.Activities.Services/Projections/CashMovementProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/CashMovementProjection.cs
@@ -18,6 +18,7 @@ namespace MarginTrading.Activities.Services.Projections
             IIdentityGenerator identityGenerator,
             IAccountsService accountService)
         {
+            _identityGenerator = identityGenerator;
             _cqrsSender = cqrsSender;
             _accountService = accountService;
         }

--- a/src/MarginTrading.Activities.Services/Projections/CashMovementProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/CashMovementProjection.cs
@@ -11,17 +11,19 @@ namespace MarginTrading.Activities.Services.Projections
     {
         private readonly IActivitiesSender _cqrsSender;
         private readonly IIdentityGenerator _identityGenerator;
+        private readonly IAccountsService _accountService;
 
         public CashMovementProjection(
             IActivitiesSender cqrsSender,
-            IIdentityGenerator identityGenerator)
+            IIdentityGenerator identityGenerator,
+            IAccountsService accountService)
         {
             _cqrsSender = cqrsSender;
-            _identityGenerator = identityGenerator;
+            _accountService = accountService;
         }
 
         [UsedImplicitly]
-        public Task Handle(DepositSucceededEvent e)
+        public async Task Handle(DepositSucceededEvent e)
         {
             var activity = new Activity(
                     id: _identityGenerator.GenerateId(),
@@ -30,16 +32,14 @@ namespace MarginTrading.Activities.Services.Projections
                     eventSourceId: e.AccountId, 
                     timestamp: e.EventTimestamp,
                     @event: ActivityType.AccountDepositSucceeded,
-                    descriptionAttributes: GetDescriptionAtributes(e), 
+                    descriptionAttributes: await GetDescriptionAtributes(e, e.AccountId), 
                     relatedIds: Array.Empty<string>());
             
             _cqrsSender.PublishActivity(activity);
-
-            return Task.CompletedTask;
         } 
         
         [UsedImplicitly]
-        public Task Handle(DepositFailedEvent e)
+        public async Task Handle(DepositFailedEvent e)
         {
             var activity = new Activity(
                     id: _identityGenerator.GenerateId(),
@@ -48,16 +48,14 @@ namespace MarginTrading.Activities.Services.Projections
                     eventSourceId: e.AccountId,
                     timestamp: e.EventTimestamp,
                     @event: ActivityType.AccountDepositFailed,
-                    descriptionAttributes: GetDescriptionAtributes(e),
+                    descriptionAttributes: await GetDescriptionAtributes(e, e.AccountId),
                     relatedIds: Array.Empty<string>());
             
             _cqrsSender.PublishActivity(activity);
-
-            return Task.CompletedTask;
         }
 
         [UsedImplicitly]
-        public Task Handle(WithdrawalSucceededEvent e)
+        public async Task Handle(WithdrawalSucceededEvent e)
         {
             var activity = new Activity(
                     id: _identityGenerator.GenerateId(),
@@ -66,16 +64,14 @@ namespace MarginTrading.Activities.Services.Projections
                     eventSourceId: e.AccountId, 
                     timestamp: e.EventTimestamp,
                     @event: ActivityType.AccountWithdrawalSucceeded,
-                    descriptionAttributes: GetDescriptionAtributes(e),
+                    descriptionAttributes: await GetDescriptionAtributes(e, e.AccountId),
                     relatedIds: Array.Empty<string>());
             
             _cqrsSender.PublishActivity(activity);
-
-            return Task.CompletedTask;
         }
 
         [UsedImplicitly]
-        public Task Handle(WithdrawalFailedEvent e)
+        public async Task Handle(WithdrawalFailedEvent e)
         {
             var activity = new Activity(
                     id: _identityGenerator.GenerateId(),
@@ -84,29 +80,27 @@ namespace MarginTrading.Activities.Services.Projections
                     eventSourceId: e.AccountId, 
                     timestamp: e.EventTimestamp,
                     @event: ActivityType.AccountWithdrawalFailed,
-                    descriptionAttributes: GetDescriptionAtributes(e),
+                    descriptionAttributes: await GetDescriptionAtributes(e, e.AccountId),
                     relatedIds: Array.Empty<string>());
             
             _cqrsSender.PublishActivity(activity);
-
-            return Task.CompletedTask;
         }
         
-        private string[] GetDescriptionAtributes(BaseEvent @event)
+        private async Task<string[]> GetDescriptionAtributes(BaseEvent @event, string accountId)
         {
             switch(@event)
             {
                 case DepositSucceededEvent e:
-                    return new string[] { e.Amount.ToString(), e.Currency };
+                    return new string[] { e.Amount.ToString(), e.Currency, await _accountService.GetEitherAccountNameOrAccountId(accountId) };
 
                 case DepositFailedEvent e: 
-                    return new string[] { e.Amount.ToString(), e.Currency };
+                    return new string[] { e.Amount.ToString(), e.Currency, await _accountService.GetEitherAccountNameOrAccountId(accountId) };
 
                 case WithdrawalSucceededEvent e:
-                    return new string[] { e.Amount.ToString(), e.Currency };
+                    return new string[] { e.Amount.ToString(), e.Currency, await _accountService.GetEitherAccountNameOrAccountId(accountId) };
 
                 case WithdrawalFailedEvent e:
-                    return new string[] { e.Amount.ToString(), e.Currency };
+                    return new string[] { e.Amount.ToString(), e.Currency, await _accountService.GetEitherAccountNameOrAccountId(accountId) };
 
                 default:
                     return Array.Empty<string>();

--- a/src/MarginTrading.Activities.Services/Projections/LiquidationProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/LiquidationProjection.cs
@@ -36,7 +36,7 @@ namespace MarginTrading.Activities.Services.Projections
                 eventSourceId: @event.OperationId,
                 @event.CreationTime,
                 @event: ActivityType.CloseAllStarted,
-                descriptionAttributes: new [] { accountName ?? @event.AccountId },
+                descriptionAttributes: new [] { await _accountsService.GetEitherAccountNameOrAccountId(@event.AccountId) },
                 relatedIds: Array.Empty<string>());
 
             _publisher.PublishActivity(activity);

--- a/src/MarginTrading.Activities.Services/Projections/SessionActivityProjection.cs
+++ b/src/MarginTrading.Activities.Services/Projections/SessionActivityProjection.cs
@@ -52,7 +52,7 @@ namespace MarginTrading.Activities.Services.Projections
             var activityType = ActivityType.None;
             var descriptionAttributes = new List<string>();
             var relatedIds = new string[0];
-            var accountName = await _accountsService.GetAccountNameByAccountId(sessionEvent.AccountId);
+            var accountName = await _accountsService.GetEitherAccountNameOrAccountId(sessionEvent.AccountId);
 
             switch (sessionEvent.Type)
             {
@@ -112,19 +112,17 @@ namespace MarginTrading.Activities.Services.Projections
 
         private static IEnumerable<string> GetDescriptionForLogInLogOut(SessionActivity sessionEvent, string accountName)
         {
-            var accountId = string.IsNullOrEmpty(accountName) ? sessionEvent.AccountId : accountName;
             return new []
             {
-                sessionEvent.UserName, accountId, sessionEvent.SessionId.ToString(),
+                sessionEvent.UserName, accountName, sessionEvent.SessionId.ToString(),
             };
         }
 
         private static IEnumerable<string> GetDescriptionForOnBehalfSupport(SessionActivity sessionEvent, string accountName)
         {
-            var accountId = string.IsNullOrEmpty(accountName) ? sessionEvent.AccountId : accountName;
             return new []
             {
-                accountId, sessionEvent.UserName,
+                accountName, sessionEvent.UserName,
             };
         }
     }

--- a/tests/MarginTrading.Activities.Tests/AccountServiceTests.cs
+++ b/tests/MarginTrading.Activities.Tests/AccountServiceTests.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MarginTrading.AccountsManagement.Contracts;
+using MarginTrading.AccountsManagement.Contracts.Models;
+using MarginTrading.Activities.Services;
+using Moq;
+using NUnit.Framework;
+
+namespace MarginTrading.Activites.Tests
+{
+    class AccountIdAndNameTestCase : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { };
+            yield return new object[] { };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class AccountServiceTests
+    {
+        private static IEnumerable<TestCaseData> AccountIdAndNameTestCase
+        {
+            get 
+            {
+                yield return new TestCaseData(new AccountContract() { Id = "id-1", AccountName = "accountName-a1" }, "accountName-a1");
+                yield return new TestCaseData(new AccountContract() { Id = "id-2" }, "id-2");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(AccountIdAndNameTestCase))]
+        public async Task GetEitherAccountNameOrAccountId_ShouldReturnAccountName_WhenApplicable(AccountContract account, string expected)
+        {
+            var mockAccountsApi = new Mock<IAccountsApi>();
+            mockAccountsApi.Setup(mock => mock.GetById(It.IsAny<string>())).ReturnsAsync(account);
+
+            var sut = CreateSut(mockAccountsApi.Object);
+            var result = await sut.GetEitherAccountNameOrAccountId(account.Id);
+            
+            Assert.AreEqual(expected, result);
+        }
+        
+        private AccountService CreateSut(IAccountsApi accountsApiArg = null)
+        {
+            IAccountsApi accountsApi = new Mock<IAccountsApi>().Object;
+            
+            if(accountsApiArg != null)
+            {
+                accountsApi = accountsApiArg;
+            }
+
+            return new AccountService(accountsApi);
+        }
+    }
+}

--- a/tests/MarginTrading.Activities.Tests/CashMovementProjectionTests.cs
+++ b/tests/MarginTrading.Activities.Tests/CashMovementProjectionTests.cs
@@ -158,9 +158,16 @@ namespace MarginTrading.Activites.Tests
             Assert.AreEqual(expected: e.Amount.ToString(), actual: actualActivity.DescriptionAttributes[0]);
         }
         
-        private CashMovementProjection CreateSut(IIdentityGenerator identityGenerator)
+        private CashMovementProjection CreateSut(IIdentityGenerator identityGenerator, IAccountsService accountsServiceArg = null)
         {
-            return new CashMovementProjection(_activitiesSenderStub, identityGenerator);
+            IAccountsService accountsService = new Mock<IAccountsService>().Object;
+            
+            if(accountsServiceArg != null)
+            {
+                accountsService = accountsServiceArg;
+            }
+
+            return new CashMovementProjection(_activitiesSenderStub, identityGenerator, accountsService);
         }
     }
 }


### PR DESCRIPTION
This PR adds changes to use AccountName within the Activity DescriptionAttributes where applicable. Inserts either `AccountName` or `AccountId`. (`AccountName` if there's an `AccountName` for the account, `AccountId` otherwise.)